### PR TITLE
updated associate_public_ip_address to false

### DIFF
--- a/analysis.tf
+++ b/analysis.tf
@@ -20,7 +20,7 @@ resource "aws_instance" "analysis" {
   instance_type               = var.namespace == "prod" ? "t3a.small" : "t3a.small"
   iam_instance_profile        = aws_iam_instance_profile.httpd_server_instance_profile.id
   vpc_security_group_ids      = [aws_security_group.analysis.id]
-  associate_public_ip_address = true
+  associate_public_ip_address = false
   monitoring                  = true
   private_ip                  = var.analysis_instance_ip
   subnet_id                   = aws_subnet.ops_public_subnet.id


### PR DESCRIPTION
AWS Security Hub control EC2.9 flags EC2 instances that are assigned a public IPv4 address. Publicly accessible instances increase the attack surface and may allow direct access from the internet.

**Setting:**
Terraformassociate_public_ip_address = false

Ensures that the Analysis EC2 instance is provisioned without a public IPv4 address, restricting access to private network routes only (e.g., VPN, bastion host, or internal connectivity mechanisms).

**Security Impact:**

- Prevents direct internet exposure of the Analysis server.
- Reduces attack surface and aligns with AWS Security Hub control EC2.9.
- Supports security best practices by enforcing private-only access for the instance.