### PR TITLE
Remove Elastic IP from analysis EC2 instance

### DIFF
--- a/analysis.tf
+++ b/analysis.tf
@@ -127,7 +127,7 @@ EOF
     ignore_changes = [
       ami,
       user_data,
-      associate_public_ip_address,
+      #associate_public_ip_address,
     ]
   }
 }
@@ -168,10 +168,10 @@ resource "aws_security_group" "analysis" {
   }
 }
 
-resource "aws_eip" "analysis_eip" {
-  instance = aws_instance.analysis.id
-  domain   = "vpc"
-}
+#resource "aws_eip" "analysis_eip" {
+#  instance = aws_instance.analysis.id
+#  domain   = "vpc"
+#}
 
 resource "aws_route" "apps-tab" {
   route_table_id            = aws_route_table.ops_public_table.id

--- a/output.tf
+++ b/output.tf
@@ -30,7 +30,7 @@ output "httpd_config_bucket" {
   value = aws_s3_bucket.httpd_config_bucket.id
 }
 
-output "analysis_eip" {
-  value = aws_eip.analysis_eip.public_ip
-}
+#output "analysis_eip" {
+#  value = aws_eip.analysis_eip.public_ip
+#}
 


### PR DESCRIPTION
- Remove aws_eip.analysis_eip resource
- Prevent public IP attachment to analysis instance
- Retain associate_public_ip_address = false on aws_instance
- Ensure analysis server is accessible only via private IP